### PR TITLE
feat: add support for drone plugin env vars

### DIFF
--- a/bin/dokku-deploy
+++ b/bin/dokku-deploy
@@ -1,6 +1,22 @@
 #!/bin/sh -l
 set -e
 
+if [ -n "$PLUGIN_BRANCH" ]; then
+  export BRANCH="$PLUGIN_BRANCH"
+fi
+if [ -n "$PLUGIN_COMMAND" ]; then
+  export COMMAND="$PLUGIN_COMMAND"
+fi
+if [ -n "$PLUGIN_GIT_REMOTE_URL" ]; then
+  export GIT_REMOTE_URL="$PLUGIN_GIT_REMOTE_URL"
+fi
+if [ -n "$PLUGIN_GIT_PUSH_FLAGS" ]; then
+  export GIT_PUSH_FLAGS="$PLUGIN_GIT_PUSH_FLAGS"
+fi
+if [ -n "$PLUGIN_REVIEW_APP_NAME" ]; then
+  export REVIEW_APP_NAME="$PLUGIN_REVIEW_APP_NAME"
+fi
+
 setup-ssh
 
 commit_sha="$(parse-ci-commit)"

--- a/bin/parse-app-name
+++ b/bin/parse-app-name
@@ -1,4 +1,8 @@
 #!/bin/sh -l
 set -e
 
+if [ -n "$PLUGIN_GIT_REMOTE_URL" ]; then
+  export GIT_REMOTE_URL="$PLUGIN_GIT_REMOTE_URL"
+fi
+
 echo "$GIT_REMOTE_URL" | sed -e 's/.*\///'

--- a/bin/parse-ci-branch-name
+++ b/bin/parse-ci-branch-name
@@ -4,6 +4,9 @@ set -e
 value="$CI_BRANCH_NAME"
 if [ -n "$CI_BRANCH_NAME" ]; then
   true
+elif [ -n "$PLUGIN_CI_BRANCH_NAME" ]; then
+  # drone plugin
+  value="$PLUGIN_CI_BRANCH_NAME"
 elif [ -n "$CIRCLE_BRANCH" ]; then
   # circleci
   value="$CIRCLE_BRANCH"

--- a/bin/parse-ci-commit
+++ b/bin/parse-ci-commit
@@ -4,6 +4,9 @@ set -e
 value="$CI_COMMIT"
 if [ -n "$CI_COMMIT" ]; then
   true
+elif [ -n "$PLUGIN_CI_COMMIT" ]; then
+  # drone plugin
+  value="$PLUGIN_CI_COMMIT"
 elif [ -n "$CIRCLE_SHA1" ]; then
   # circleci
   value="$CIRCLE_SHA1"

--- a/bin/parse-ssh-host
+++ b/bin/parse-ssh-host
@@ -1,4 +1,8 @@
 #!/bin/sh -l
 set -e
 
+if [ -n "$PLUGIN_GIT_REMOTE_URL" ]; then
+  export GIT_REMOTE_URL="$PLUGIN_GIT_REMOTE_URL"
+fi
+
 echo "$GIT_REMOTE_URL" | sed -e 's/.*@//' -e 's/[:/].*//'

--- a/bin/parse-ssh-port
+++ b/bin/parse-ssh-port
@@ -1,6 +1,10 @@
 #!/bin/sh -l
 set -e
 
+if [ -n "$PLUGIN_GIT_REMOTE_URL" ]; then
+  export GIT_REMOTE_URL="$PLUGIN_GIT_REMOTE_URL"
+fi
+
 ssh_port="$(echo "$GIT_REMOTE_URL" | sed -e 's/.*@//' -e 's/\/.*//' -ne 's/.*:\([0-9]*\)/\1/p')"
 if [ -z "$ssh_port" ]; then
   ssh_port=22

--- a/bin/setup-ssh
+++ b/bin/setup-ssh
@@ -1,6 +1,13 @@
 #!/bin/sh -l
 set -e
 
+if [ -n "$PLUGIN_SSH_HOST_KEY" ]; then
+  export SSH_HOST_KEY="$PLUGIN_SSH_HOST_KEY"
+fi
+if [ -n "$PLUGIN_SSH_PRIVATE_KEY" ]; then
+  export SSH_PRIVATE_KEY="$PLUGIN_SSH_PRIVATE_KEY"
+fi
+
 log-info "Setting up SSH Key"
 
 mkdir -p /root/.ssh


### PR DESCRIPTION
Drone plugins have their settings upper-cased and prefixed with `PLUGIN_`, but are otherwise plain docker images.