### PR TITLE
Fix review-apps:destroy command

### DIFF
--- a/bin/dokku-deploy
+++ b/bin/dokku-deploy
@@ -20,7 +20,7 @@ if [ "$COMMAND" = "review-apps:create" ] || [ "$COMMAND" = 'review-apps:destroy'
   fi
 fi
 
-if [ "$COMMAND" = "review-app:destroy" ]; then
+if [ "$COMMAND" = "review-apps:destroy" ]; then
   log-info "Destroying review app '${REVIEW_APP_NAME}'"
   ssh "$ssh_remote" -- --force apps:destroy "$REVIEW_APP_NAME"
   exit 0


### PR DESCRIPTION
As stated in https://github.com/dokku/github-action, the correct command should be `review-apps:destroy`. 