### PR TITLE
Fix ansi color output

### DIFF
--- a/bin/log-error
+++ b/bin/log-error
@@ -1,5 +1,7 @@
 #!/bin/sh -l
+# shellcheck shell=ash
 set -e
 
 message="$*"
-echo "\u001b[31m${message}\u001b[0m" 1>&2
+# shellcheck disable=SC2169
+echo -e "\e[31m${message}\e[0m" 1>&2

--- a/bin/log-info
+++ b/bin/log-info
@@ -1,6 +1,8 @@
 #!/bin/sh -l
+# shellcheck shell=ash
 set -e
 
 message="$*"
 echo ""
-echo "\u001b[32m${message}\u001b[0m"
+# shellcheck disable=SC2169
+echo -e "\e[32m${message}\e[0m"


### PR DESCRIPTION
This change attempts to fix the color output in GitHub Actions:

```console
\u001b[32mSetting up SSH Key\u001b[0m

\u001b[32mGenerating SSH_HOST_KEY from ssh-keyscan against ***:22\u001b[0m
# ***:22 SSH-2.0-OpenSSH_8.2p1 Ubuntu-4ubuntu0.1
# ***:22 SSH-2.0-OpenSSH_8.2p1 Ubuntu-4ubuntu0.1
# ***:22 SSH-2.0-OpenSSH_8.2p1 Ubuntu-4ubuntu0.1
# ***:22 SSH-2.0-OpenSSH_8.2p1 Ubuntu-4ubuntu0.1
# ***:22 SSH-2.0-OpenSSH_8.2p1 Ubuntu-4ubuntu0.1

\u001b[32mAdding SSH Key to ssh-agent\u001b[0m
Agent pid 24
Identity added: /root/.ssh/id_rsa (user@host.local)

\u001b[32mEnsuring review app 'staging-richardwillis' exists\u001b[0m
Warning: Permanently added the ECDSA host key for IP address 'xxxxxx' to the list of known hosts.
 !     Name is already taken

\u001b[32mPushing to Dokku Host\u001b[0m
```