### PR TITLE
Added git:from-image to commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,11 @@ The following environment variables are supported:
   - required: false
   - default: ''
 - `SSH_PRIVATE_KEY`:
-  - description: A private SSH key that has push acces to your Dokku instance
+  - description: A private SSH key that has push access to your Dokku instance
   - required: true
-
+- `IMAGE_NAME`:
+  - description: A docker image name/tag to deploy to the Dokku instance
+  - required: true if `COMMAND` is set to `git:from-image`, otherwise false
 ## Building
 
 ```text

--- a/README.md
+++ b/README.md
@@ -79,3 +79,53 @@ The following environment variables are supported:
 ```text
 docker build dokku/ci-docker-image .
 ```
+
+
+
+## Examples
+
+Where `DOKKU_SERVER_IP` is the URL or IP Address of the host running dokku.
+and `DOKKU_APP_NAME` is the app which has been created on dokku.
+
+### Basic Deploy using the Git Repository of the CI
+Using Gitlab-CI:
+```yaml
+deploy:
+  stage: deploy
+  image: dokku/ci-docker-image
+  variables:
+    GIT_DEPTH: 0
+    GIT_REMOTE_URL: ssh://dokku@${DOKKU_SERVER_IP}:22/${DOKKU_APP_NAME}
+  script:
+    - dokku-deploy
+  after_script:
+    - dokku-unlock
+```
+
+
+### Deploying an Existing Docker Image
+To deploy an existing docker image rather than the git repository. For instance, if the docker image is built in a previous step of the pipeline.
+
+Replace `existing/docker-image:$VERSION` with your own docker image and tag. 
+
+Using Gitlab-CI:
+```yaml
+deploy:
+  stage: deploy
+  image: dokku/ci-docker-image
+  variables:
+    GIT_STRATEGY: none
+    GIT_REMOTE_URL: ssh://dokku@${DOKKU_SERVER_IP}:22/${DOKKU_APP_NAME}
+    COMMAND: git:from-image
+  before_script:
+    # version as artifact from previous pipeline step
+    - export VERSION=$(cat ./version)  
+    # must use specific version deploying latest on top of latest will not trigger a deploy
+    - export IMAGE_NAME=existing/docker-image:$VERSION 
+  script:
+    - dokku-deploy
+  after_script:
+    - dokku-unlock
+
+```
+

--- a/bin/dokku-deploy
+++ b/bin/dokku-deploy
@@ -66,8 +66,6 @@ if [ -z "$commit_sha" ]; then
   exit 1
 fi
 
-
-
 if [ "$COMMAND" = "review-apps:create" ]; then
   log-info "Ensuring review app '${REVIEW_APP_NAME}' exists"
   ssh "$ssh_remote" -- apps:clone --skip-deploy --ignore-existing "$app_name" "$REVIEW_APP_NAME"

--- a/bin/dokku-deploy
+++ b/bin/dokku-deploy
@@ -46,6 +46,16 @@ if [ "$COMMAND" = "review-apps:destroy" ]; then
   exit 0
 fi
 
+if [ "$COMMAND" = "git:from-image" ]; then
+  if [-z "$IMAGE_NAME"]; then
+    log-error "No docker image specified"
+    exit 1
+  fi
+
+  ssh "$ssh_remote" -- git:from-image "$app_name" "$IMAGE_NAME"
+  exit 0
+fi
+
 if [ -n "$COMMAND" ] && [ "$COMMAND" != "review-apps:create" ] && [ "$COMMAND" != "deploy" ]; then
   log-error "Invalid command specified"
   exit 1
@@ -55,6 +65,8 @@ if [ -z "$commit_sha" ]; then
   log-error "Unable to detect commit sha"
   exit 1
 fi
+
+
 
 if [ "$COMMAND" = "review-apps:create" ]; then
   log-info "Ensuring review app '${REVIEW_APP_NAME}' exists"


### PR DESCRIPTION
Added git:from-image to the commands which allows the direct deployment of an existing docker image.

Env variables required:
COMMAND: git:from-image
IMAGE_NAME: some-docker/image:here

