### PR TITLE
Mark working directory as safe for git commands

### DIFF
--- a/bin/dokku-deploy
+++ b/bin/dokku-deploy
@@ -89,6 +89,7 @@ if [ -n "$DEPLOY_DOCKER_IMAGE" ]; then
   ssh "$ssh_remote" -- git:from-image "$remote_app_name" "$DEPLOY_DOCKER_IMAGE" "$DEPLOY_USER_NAME" "$DEPLOY_USER_EMAIL"
 else
   log-info "Pushing to Dokku Host"
+  git config --global --add safe.directory "$PWD"
   # shellcheck disable=SC2086
   git push $GIT_PUSH_FLAGS "$GIT_REMOTE_URL" "$commit_sha:refs/heads/$BRANCH"
 fi

--- a/bin/parse-ci-commit
+++ b/bin/parse-ci-commit
@@ -29,6 +29,7 @@ elif [ -n "$TRAVIS_COMMIT" ]; then
   # travisci
   value="$TRAVIS_COMMIT"
 else
+  git config --global --add safe.directory "$PWD"
   value=$(git rev-parse HEAD 2>/dev/null || true)
 fi
 


### PR DESCRIPTION
Newer git versions - newer than 2.35.2 - complain due to a security patch. This patch is for multi-user systems or Windows machines. Fortunately, the issue isn't _really_ an issue for the CI use-case, so it is okay to mark the directory as safe.

See https://github.blog/2022-04-12-git-security-vulnerability-announced/ for more details.

Closes #25