### PR TITLE
Fix permissions when using ssh-keyscan

### DIFF
--- a/bin/setup-ssh
+++ b/bin/setup-ssh
@@ -25,6 +25,7 @@ else
 
   log-info "Generating SSH_HOST_KEY from ssh-keyscan against $ssh_host:$ssh_port"
   ssh-keyscan -H -p "$ssh_port" "$ssh_host" >>/root/.ssh/known_hosts
+  chmod 600 "/root/.ssh/known_hosts"
 fi
 
 log-info "Adding SSH Key to ssh-agent"


### PR DESCRIPTION
When using ssh-keyscan the connection gets refused because known_hosts permissions don't get set.