### PR TITLE
refactor: switch to non-deprecated method for setting output in github actions

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -40,8 +40,8 @@ jobs:
             echo -e "\u001b[32mDetected success lint workflow_run conclusion\u001b[0m"
           fi
 
-          echo "::set-output name=push-enabled::${push_enabled}"
-          echo "::set-output name=docker-image-tag::${image_tag}"
+          run: echo "push-enabled=${push_enabled}" >> $GITHUB_OUTPUT
+          run: echo "docker-image-tag=${image_tag}" >> $GITHUB_OUTPUT
 
   docker-push:
     name: push latest


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ of more details.