### PR TITLE
feat: switch default branch to main

### DIFF
--- a/.github/workflows/docker-push.yaml
+++ b/.github/workflows/docker-push.yaml
@@ -34,8 +34,8 @@ jobs:
             echo -e "\u001b[32mDetected semver tag\u001b[0m"
             image_tag='${{ github.event.workflow_run.head_branch }}'
             push_enabled=true
-          elif [[ '${{ github.event.workflow_run.head_branch }}' == "master" ]]; then
-            echo -e "\u001b[32mDetected master branch\u001b[0m"
+          elif [[ '${{ github.event.workflow_run.head_branch }}' == "main" ]]; then
+            echo -e "\u001b[32mDetected main branch\u001b[0m"
             push_enabled=true
           elif [[ '${{github.ref_name}}' =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             echo -e "\u001b[32mDetected semver tag\u001b[0m"
@@ -43,7 +43,7 @@ jobs:
             push_enabled=true
             is_tagged=true
           else
-            echo "::warning ::Unable to detect semver tag or master branch"
+            echo "::warning ::Unable to detect semver tag or main branch"
             push_enabled=false
           fi
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,7 +8,7 @@ on:
       - "*"
   push:
     branches:
-      - "master"
+      - "main"
 
 concurrency:
   group: lint-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/trivy-analysis.yaml
+++ b/.github/workflows/trivy-analysis.yaml
@@ -5,7 +5,7 @@ name: trivy-analysis
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 concurrency:
@@ -27,13 +27,13 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: 'docker.io/dokku/ci-docker-image:${{ github.sha }}'
-          format: 'template'
-          template: '@/contrib/sarif.tpl'
-          output: 'trivy-results.sarif'
-          severity: 'CRITICAL,HIGH'
+          image-ref: "docker.io/dokku/ci-docker-image:${{ github.sha }}"
+          format: "template"
+          template: "@/contrib/sarif.tpl"
+          output: "trivy-results.sarif"
+          severity: "CRITICAL,HIGH"
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: 'trivy-results.sarif'
+          sarif_file: "trivy-results.sarif"


### PR DESCRIPTION
Due to local tooling updates, all the other Dokku repositories are converging on 'main' as the default. This makes my local workflows for interacting with this repository annoying as I need to remember if the repo uses main or master. As such, the default branch is moving to main to reduce cognitive overhead while I maintain the repository.