### PR TITLE
Update parse-ssh-host to fix a mismatched quotes in new trace code.

### DIFF
--- a/bin/parse-ssh-host
+++ b/bin/parse-ssh-host
@@ -13,7 +13,7 @@ def is_ipv6(ip):
     try:
         return isinstance(ipaddress.ip_address(ip), ipaddress.IPv6Address)
     except ValueError:
-        if os.getenv("TRACE") != "':
+        if os.getenv("TRACE") != "":
             print(f"Invalid IP address: {ip}", file=sys.stderr)
         return False
 


### PR DESCRIPTION
Hi  there, it looks like there was a typo in the python file.

This just fixes that.