### PR TITLE
feat: add automatic detection of woodpecker ci environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.21.3
 
-RUN apk --no-cache add git==2.47.2-r0 python3==3.12.9-r0 openssh==9.9_p2-r0 && \
+RUN apk --no-cache add git==2.47.2-r0 python3==3.12.10-r0 openssh==9.9_p2-r0 && \
     mkdir -p ~/.ssh
 
 COPY bin /bin

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ detected:
 - [gitlab-ci](https://about.gitlab.com/stages-devops-lifecycle/continuous-integration/)
 - [semaphoreci](https://semaphoreci.com/)
 - [travisci](https://travis-ci.com/)
+- [woodpecker ci](https://woodpecker-ci.org/)
 
 ## Usage
 

--- a/bin/parse-ci-branch-name
+++ b/bin/parse-ci-branch-name
@@ -32,6 +32,9 @@ elif [ -n "$SEMAPHORE_GIT_BRANCH" ]; then
 elif [ -n "$TRAVIS_BRANCH" ]; then
   # travisci
   value="$TRAVIS_BRANCH"
+elif [ -n "$CI_COMMIT_BRANCH" ]; then
+  # woodpecker ci
+  value="$CI_COMMIT_BRANCH"
 else
   exit 0
 fi

--- a/bin/parse-ci-commit
+++ b/bin/parse-ci-commit
@@ -24,7 +24,7 @@ elif [ -n "$GITHUB_SHA" ]; then
   # github actions
   value="$GITHUB_SHA"
 elif [ -n "$CI_COMMIT_SHA" ]; then
-  # gitlab-ci
+  # gitlab-ci and woodpecker ci
   value="$CI_COMMIT_SHA"
 elif [ -n "$SEMAPHORE_GIT_SHA" ]; then
   # semaphoreci


### PR DESCRIPTION
Only the commit branch differs from other CI solutions. `CI_COMMIT_SHA` is identical to GitLab CI, so I just added a comment.

I had to change the Dockerfile so that I could build the image locally for testing: I needed to update `python3` to `3.12.10-r0`, but didn't add it to the MR to keep things clean.